### PR TITLE
Use generators instead of generator functions

### DIFF
--- a/cooperative/__init__.py
+++ b/cooperative/__init__.py
@@ -26,27 +26,27 @@ def accumulation_handler(stopped_generator, spigot):
     return spigot.drain_contents()
 
 
-def accumulate(a_generator_func):
+def accumulate(a_generator):
     """
     Start a Deferred whose callBack arg is a deque of the accumulation
-    of the values yielded from a_generator_func.
+    of the values yielded from a_generator.
 
-    :param a_generator_func: A function which returns a generator.
+    :param a_generator: An iterator which yields some not None values.
     :return: A Deferred to which the next callback will be called with
      the yielded contents of the generator function.
     """
 
     spigot = Bucket(lambda x: x)
-    items = stream_tap((spigot,), a_generator_func())
+    items = stream_tap((spigot,), a_generator)
     d = cooperate(items).whenDone()
     d.addCallback(accumulation_handler, spigot)
     return d
 
 
-def batch_accumulate(max_batch_size, a_generator_func):
+def batch_accumulate(max_batch_size, a_generator):
     """
     Start a Deferred whose callBack arg is a deque of the accumulation
-    of the values yielded from a_generator_func which is iterated over
+    of the values yielded from a_generator which is iterated over
     in batches the size of max_batch_size.
 
     It should be more efficient to iterate over the generator in
@@ -54,13 +54,13 @@ def batch_accumulate(max_batch_size, a_generator_func):
 
     :param max_batch_size: The number of iterations of the generator
      to consume at a time.
-    :param a_generator_func: A function which returns a generator.
+    :param a_generator: An iterator which yields some not None values.
     :return: A Deferred to which the next callback will be called with
      the yielded contents of the generator function.
     """
     from twisted.internet.task import cooperate
     spigot = Bucket(lambda x: x)
-    items = stream_tap((spigot,), a_generator_func())
+    items = stream_tap((spigot,), a_generator)
 
     d = cooperate(i_batch(max_batch_size, items)).whenDone()
     d.addCallback(accumulation_handler, spigot)

--- a/cooperative/tests/test_cooperative.py
+++ b/cooperative/tests/test_cooperative.py
@@ -1,6 +1,5 @@
 # _*_ coding: utf-8 _*_
 from collections import deque
-from functools import partial
 from itertools import chain
 
 from twisted.internet import defer
@@ -54,10 +53,10 @@ def run_some_with_error(value):
     :return:
     """
     #  first deferred
-    result = yield accumulate(partial(i_get_tenth_11, value))
+    result = yield accumulate(i_get_tenth_11(value))
 
     try:
-        result2 = yield accumulate(partial(i_get_tenth_11, result))
+        result2 = yield accumulate(i_get_tenth_11(result))
         defer.returnValue(result2)
     except IndexError, e:
         log.err(e)
@@ -75,10 +74,10 @@ def run_some_without_error(value):
     :return:
     """
     #  first deferred
-    result = yield accumulate(partial(i_get_tenth_11, list(range(110, 150))))
+    result = yield accumulate(i_get_tenth_11(range(110, 150)))
 
     log.msg("accumulated {}".format(result))
-    result = yield accumulate(partial(i_get_tenth_11, value))
+    result = yield accumulate(i_get_tenth_11(value))
     defer.returnValue(result)
 
 
@@ -92,7 +91,7 @@ class TestAccumulate(unittest.TestCase):
 
         :return:
         """
-        result = yield accumulate(partial(i_get_tenth_11, list(range(110, 150))))
+        result = yield accumulate(i_get_tenth_11(range(110, 150)))
         self.assertEqual(result, deque([120, 121]))
 
 
@@ -108,7 +107,7 @@ class TestAccumulate(unittest.TestCase):
 
         :return:
         """
-        result = yield run_some_with_error(list(range(15)))
+        result = yield run_some_with_error(range(15))
         self.assertEqual(result, "Couldn't get second result, "
                                  "but the first result is deque([10, 11])")
 
@@ -123,8 +122,8 @@ class TestAccumulate(unittest.TestCase):
 
         :return:
         """
-        d1 = run_some_without_error(list(range(15)))
-        d2 = run_some_without_error(list(range(15, 100)))
+        d1 = run_some_without_error(range(15))
+        d2 = run_some_without_error(range(15, 100))
         result = yield defer.gatherResults([d1, d2])
 
         self.assertEqual(result, [deque([10, 11]), deque([25, 26])])
@@ -136,9 +135,9 @@ class TestAccumulate(unittest.TestCase):
 
         :return:
         """
-        d1 = run_some_without_error(list(range(15)))
-        d2 = run_some_without_error(list(range(15, 100)))
-        d3 = accumulate(partial(i_get_tenth_11, list(range(4, 50))))
+        d1 = run_some_without_error(range(15))
+        d2 = run_some_without_error(range(15, 100))
+        d3 = accumulate(i_get_tenth_11(range(4, 50)))
         result = yield defer.gatherResults([d1, d2, d3])
 
         self.assertEqual(result, [deque([10, 11]),
@@ -171,10 +170,10 @@ class TestAccumulate(unittest.TestCase):
                 yield item
 
         result = yield defer.gatherResults([
-            accumulate(partial(watcher, list(range(0, 15)))),
-            accumulate(partial(watcher, list(range(15, 100)))),
-            accumulate(partial(watcher, list(range(98, 200)))),
-            accumulate(partial(watcher, list(range(145, 189))))
+            accumulate(watcher(range(0, 15))),
+            accumulate(watcher(range(15, 100))),
+            accumulate(watcher(range(98, 200))),
+            accumulate(watcher(range(145, 189)))
         ])
 
         final_result = list(chain.from_iterable(result))
@@ -234,11 +233,10 @@ class TestAccumulate(unittest.TestCase):
                 yield item
 
         result = yield defer.gatherResults([
-            accumulate(partial(watcher, list(range(0, 15)))),
-            accumulate(partial(watcher, list(range(15, 100)))),
-            accumulate(partial(deux_watcher,
-                                           list(range(1098, 10200)))),
-            accumulate(partial(watcher, list(range(145, 189))))
+            accumulate(watcher(range(0, 15))),
+            accumulate(watcher(range(15, 100))),
+            accumulate(deux_watcher(range(1098, 10200))),
+            accumulate(watcher(range(145, 189)))
         ])
 
         final_result = list(chain.from_iterable(result))
@@ -303,11 +301,10 @@ class TestAccumulate(unittest.TestCase):
                 yield item
 
         result = yield defer.gatherResults([
-            accumulate(partial(watcher, list(range(0, 15)))),
-            accumulate(partial(watcher, list(range(15, 100)))),
-            batch_accumulate(3, partial(deux_watcher,
-                                           list(range(1098, 10200)))),
-            accumulate(partial(watcher, list(range(145, 189))))
+            accumulate(watcher(range(0, 15))),
+            accumulate(watcher(range(15, 100))),
+            batch_accumulate(3, deux_watcher(range(1098, 10200))),
+            accumulate(watcher(range(145, 189)))
         ])
 
         final_result = list(chain.from_iterable(result))


### PR DESCRIPTION
Having accumulate accept the return value of a generator
allows for more concise code.
