### PR TITLE
Make get_requirements compatible with more pip

### DIFF
--- a/cooperative/_meta.py
+++ b/cooperative/_meta.py
@@ -1,2 +1,2 @@
-version_info = (0, 1, 6)
+version_info = (0, 1, 7)
 version = '.'.join(map(str, version_info))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-iter_karld_tools==0.9.0
-stream_tap==0.9.2
+iter_karld_tools==0.9.1
+stream_tap==0.9.3
 twisted==15.0.0

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,10 @@ def get_version():
 
 
 def get_requirements(filename):
-    reqs = parse_requirements(filename, session=uuid.uuid1())
+    try:
+        reqs = list(parse_requirements(filename))
+    except TypeError:
+        reqs = list(parse_requirements(filename, session=uuid.uuid1()))
 
     return [str(r.req) for r in reqs]
 


### PR DESCRIPTION
The new version of pip parse_requirements requires a session kwarg and a recent version doesn't accept session. This falls back to the old way if the new way doesn't work.
